### PR TITLE
Separation of authentication and claiming

### DIFF
--- a/contracts/github/IncubatorStorage.sol
+++ b/contracts/github/IncubatorStorage.sol
@@ -234,4 +234,53 @@ contract IncubatorStorage is UsingStorage {
 	function getCallbackKickerAddressKey() private pure returns (bytes32) {
 		return keccak256(abi.encodePacked("_callbackKicker"));
 	}
+
+	// IsAuthenticated
+	function setIsAuthenticated(string memory _githubRepository, bool _flag)
+		internal
+	{
+		eternalStorage().setAddress(
+			getIsAuthenticatedKey(_githubRepository),
+			_flag
+		);
+	}
+
+	function getIsAuthenticated(string memory _githubRepository)
+		public
+		view
+		returns (bool)
+	{
+		return
+			eternalStorage().getBool(getIsAuthenticatedKey(_githubRepository));
+	}
+
+	function getIsAuthenticatedKey(string memory _githubRepository)
+		private
+		pure
+		returns (bytes32)
+	{
+		return
+			keccak256(abi.encodePacked("_isAuthenticated", _githubRepository));
+	}
+
+	// Used Twitter Id
+	function setUsedTwitterId(string memory _twitterId) internal {
+		eternalStorage().setBool(getUsedTwitterIdKey(_twitterId), true);
+	}
+
+	function getUsedTwitterId(string memory _twitterId)
+		public
+		view
+		returns (bool)
+	{
+		return eternalStorage().getBool(getUsedTwitterIdKey(_twitterId));
+	}
+
+	function getUsedTwitterIdKey(string memory _twitterId)
+		private
+		pure
+		returns (bytes32)
+	{
+		return keccak256(abi.encodePacked("_usedTwitterId", _twitterId));
+	}
 }

--- a/contracts/test/github/IncubatorStorageTest.sol
+++ b/contracts/test/github/IncubatorStorageTest.sol
@@ -38,10 +38,11 @@ contract IncubatorStorageTest is IncubatorStorage {
 		setPropertyAddress(_githubRepository, _property);
 	}
 
-	function setAccountAddressTest(address _property, address _account)
-		external
-	{
-		setAccountAddress(_property, _account);
+	function setAccountAddressTest(
+		string memory _publicSignature,
+		address _account
+	) external {
+		setAccountAddress(_publicSignature, _account);
 	}
 
 	function setMarketAddressTest(address _market) external {

--- a/contracts/test/github/IncubatorStorageTest.sol
+++ b/contracts/test/github/IncubatorStorageTest.sol
@@ -62,4 +62,14 @@ contract IncubatorStorageTest is IncubatorStorage {
 	function setCallbackKickerAddressTest(address _callback) external {
 		setCallbackKickerAddress(_callback);
 	}
+
+	function setIsAuthenticatedTest(string memory _githubRepository, bool _flag)
+		external
+	{
+		setIsAuthenticated(_githubRepository, _flag);
+	}
+
+	function setUsedTwitterId(string memory _twitterId) external {
+		setUsedTwitterId(_twitterId);
+	}
 }

--- a/test/incubator/incubator-storage.ts
+++ b/test/incubator/incubator-storage.ts
@@ -71,16 +71,14 @@ describe('IncubatorStorage', () => {
 	})
 	describe('setAccountAddress, getAccountAddress', () => {
 		it('Initial value is 0x0000........', async () => {
-			const tmp = provider.createEmptyWallet()
-			const result = await storageTest.getAccountAddress(tmp.address)
+			const result = await storageTest.getAccountAddress('pubsig')
 			expect(result).to.be.equal(constants.AddressZero)
 		})
 		it('The set value can be taken as it is.', async () => {
 			const tmp1 = provider.createEmptyWallet()
-			const tmp2 = provider.createEmptyWallet()
-			await storageTest.setAccountAddressTest(tmp1.address, tmp2.address)
-			const result = await storageTest.getAccountAddress(tmp1.address)
-			expect(result).to.be.equal(tmp2.address)
+			await storageTest.setAccountAddressTest('pubsig', tmp1.address)
+			const result = await storageTest.getAccountAddress('pubsig')
+			expect(result).to.be.equal(tmp1.address)
 		})
 	})
 	describe('setMarketAddress, getMarketAddress', () => {

--- a/test/incubator/incubator-storage.ts
+++ b/test/incubator/incubator-storage.ts
@@ -130,4 +130,26 @@ describe('IncubatorStorage', () => {
 			expect(result).to.be.equal(tmp.address)
 		})
 	})
+	describe('setIsAuthenticated, getIsAuthenticated', () => {
+		it('Initial value is false', async () => {
+			const result = await storageTest.getIsAuthenticated('dummy_repo')
+			expect(result).to.be.equal(false)
+		})
+		it('The set value can be taken as it is.', async () => {
+			await storageTest.setIsAuthenticated('dummy_repo', true)
+			const result = await storageTest.getIsAuthenticated('dummy_repo')
+			expect(result).to.be.equal(true)
+		})
+	})
+	describe('setUsedTwitterId, getUsedTwitterId', () => {
+		it('Initial value is false', async () => {
+			const result = await storageTest.getUsedTwitterId('dummy_twitter_id')
+			expect(result).to.be.equal(false)
+		})
+		it('The set value can be taken as it is.', async () => {
+			await storageTest.setUsedTwitterId('dummy_twitter_id')
+			const result = await storageTest.getUsedTwitterId('dummy_twitter_id')
+			expect(result).to.be.equal(true)
+		})
+	})
 })

--- a/test/incubator/incubator.ts
+++ b/test/incubator/incubator.ts
@@ -308,7 +308,7 @@ describe('GitHubMarketIncubator', () => {
 
 	describe('start', () => {
 		describe('success', () => {
-			it('Parameters are stored in storage.', async () => {
+			it('Store the passed parameters', async () => {
 				const check = async (incubator: Contract): Promise<void> => {
 					const property = provider.createEmptyWallet()
 					const repository = 'hogehoge/rep'
@@ -387,7 +387,7 @@ describe('GitHubMarketIncubator', () => {
 			})
 		})
 		describe('fail', () => {
-			it('An error occurs when staking is zero.', async () => {
+			it('Should fail to call when the passed 3rd arg is 0', async () => {
 				const [instance, , , provider] = await init()
 				const property = provider.createEmptyWallet()
 				await expect(
@@ -397,13 +397,14 @@ describe('GitHubMarketIncubator', () => {
 						0,
 						1000,
 						10,
+						0,
 						{
 							gasLimit: 1000000,
 						}
 					)
 				).to.be.revertedWith('staking is 0.')
 			})
-			it('An error occurs when reward limit is zero.', async () => {
+			it('Should fail to call when the passed 4rd arg is 0', async () => {
 				const [instance, , , provider] = await init()
 				const property = provider.createEmptyWallet()
 				await expect(
@@ -413,13 +414,14 @@ describe('GitHubMarketIncubator', () => {
 						10,
 						0,
 						0,
+						0,
 						{
 							gasLimit: 1000000,
 						}
 					)
 				).to.be.revertedWith('reward limit is 0.')
 			})
-			it('An error occurs when reward limit is less than the lower limit.', async () => {
+			it('Should fail to call when the passed 4rd arg is less than 5th args', async () => {
 				const [instance, , , provider] = await init()
 				const property = provider.createEmptyWallet()
 				await expect(
@@ -429,13 +431,14 @@ describe('GitHubMarketIncubator', () => {
 						10,
 						10,
 						15,
+						0,
 						{
 							gasLimit: 1000000,
 						}
 					)
 				).to.be.revertedWith('limit is less than lower limit.')
 			})
-			it('only administrators and operators can do this.', async () => {
+			it('Should fail to call when the sender is not admins or operators', async () => {
 				const check = async (incubator: Contract): Promise<void> => {
 					const property = provider.createEmptyWallet()
 					const tmp = incubator.start(
@@ -444,6 +447,7 @@ describe('GitHubMarketIncubator', () => {
 						10000,
 						1000,
 						10,
+						0,
 						{
 							gasLimit: 1000000,
 						}


### PR DESCRIPTION
A user runs `authenticate` and` claimAuthorship` to get ownership of the Property token.

Then run `claim` to get the reward.